### PR TITLE
Two settings added

### DIFF
--- a/orienteer/templatetags/orienteer.py
+++ b/orienteer/templatetags/orienteer.py
@@ -36,17 +36,21 @@ def compass(filename, media):
     proj_dir = settings.COMPASS_PROJECT_DIR
     output_dir = settings.COMPASS_OUTPUT_DIR
     output_url = settings.COMPASS_OUTPUT_URL
+    use_timestamp = getattr(settings, 'COMPASS_USE_TIMESTAMP', True)
     
     needs_update = False
-
-    # get timestamp of css, if it doesn't exist we need to make it
-    try:
-        stat = os.stat(proj_dir + filename + '.css')
-        output_file_ts = stat.st_mtime
-    except:
-        output_file_ts = '1'
     
-    css = "<link rel='stylesheet' href='%s?%s' type='text/css' media='%s' />" % (output_url + filename + '.css', output_file_ts, media)
+    # get timestamp of css, if it doesn't exist we need to make it
+    if use_timestamp:
+        try:
+            stat = os.stat(proj_dir + filename + '.css')
+            output_file_ts = stat.st_mtime
+        except:
+            output_file_ts = '1'
+    else:
+        output_file_ts = None
+    
+    css = "<link rel='stylesheet' href='%s%s' type='text/css' media='%s' />" % (output_url + filename + '.css', use_timestamp and '?%s' % output_file_ts or '', media)
     
     # if we aren't debugging (in production for example), short-cicuit this madness
     if not settings.TEMPLATE_DEBUG:

--- a/orienteer/templatetags/orienteer.py
+++ b/orienteer/templatetags/orienteer.py
@@ -21,6 +21,8 @@ __version__ = '0.2'
 
 
 import os
+import re
+import sys
 from commands import getstatusoutput
 
 from django import template
@@ -31,30 +33,35 @@ register = template.Library()
 
 @register.simple_tag
 def compass(filename, media):
-    import time
-    
     proj_dir = settings.COMPASS_PROJECT_DIR
+    source_dir = getattr(settings, 'COMPASS_SOURCE_DIR', 'src')
     output_dir = settings.COMPASS_OUTPUT_DIR
     output_url = settings.COMPASS_OUTPUT_URL
     quiet_mode = getattr(settings, 'COMPASS_QUIET', False)
     use_timestamp = getattr(settings, 'COMPASS_USE_TIMESTAMP', True)
     
-    needs_update = False
-    
     # get timestamp of css, if it doesn't exist we need to make it
-    if use_timestamp:
-        try:
-            stat = os.stat(proj_dir + filename + '.css')
-            output_file_ts = stat.st_mtime
-        except:
-            output_file_ts = '1'
-    else:
-        output_file_ts = None
+    try:
+        output_file_stat = os.stat(os.path.join(proj_dir, output_dir, filename + '.css'))
+        output_file_ts = output_file_stat.st_mtime
+    except OSError:
+        output_file_ts = 1
+    
+    source_file_ts = 0
+    
+    for root, dirs, files in os.walk(os.path.join(proj_dir, source_dir)):
+        for source_file in files:
+            if source_file[-5:].lower() == '.scss':
+                source_file_stat = os.stat(os.path.join(root, source_file))
+                if source_file_stat.st_mtime > source_file_ts:
+                    source_file_ts = source_file_stat.st_mtime
+    
+    needs_update = source_file_ts > output_file_ts
     
     css = "<link rel='stylesheet' href='%s%s' type='text/css' media='%s' />" % (output_url + filename + '.css', use_timestamp and '?%s' % output_file_ts or '', media)
     
     # if we aren't debugging (in production for example), short-cicuit this madness
-    if not settings.TEMPLATE_DEBUG:
+    if not settings.TEMPLATE_DEBUG or not needs_update:
         return css
     
     cmd_dict = {

--- a/orienteer/templatetags/orienteer.py
+++ b/orienteer/templatetags/orienteer.py
@@ -36,6 +36,7 @@ def compass(filename, media):
     proj_dir = settings.COMPASS_PROJECT_DIR
     output_dir = settings.COMPASS_OUTPUT_DIR
     output_url = settings.COMPASS_OUTPUT_URL
+    quiet_mode = getattr(settings, 'COMPASS_QUIET', False)
     use_timestamp = getattr(settings, 'COMPASS_USE_TIMESTAMP', True)
     
     needs_update = False
@@ -61,9 +62,10 @@ def compass(filename, media):
         'sass_style': settings.COMPASS_STYLE, 
         'project_dir': proj_dir,  
         'output_dir': output_dir, 
+        'quiet_flag': quiet_mode and "--quiet" or ""
     }
     
-    cmd = "%(bin)s compile -s %(sass_style)s --css-dir %(output_dir)s %(project_dir)s" % cmd_dict
+    cmd = "%(bin)s compile %(quiet_flag)s -s %(sass_style)s --css-dir %(output_dir)s %(project_dir)s" % cmd_dict
     (status, output) = getstatusoutput(cmd)
     print output
     

--- a/orienteer/templatetags/orienteer.py
+++ b/orienteer/templatetags/orienteer.py
@@ -74,6 +74,8 @@ def compass(filename, media):
     
     cmd = "%(bin)s compile %(quiet_flag)s -s %(sass_style)s --css-dir %(output_dir)s %(project_dir)s" % cmd_dict
     (status, output) = getstatusoutput(cmd)
-    print output
+    if output:
+        for line in re.split("\n+", output):
+            sys.stderr.write(re.sub(r'^', '[Compass] ', line) + "\n")
     
     return css


### PR DESCRIPTION
Hi,

I've added two optional settings to django-orienteer (COMPASS_USE_TIMESTAMP and COMPASS_QUIET) for my own projects, and I got some positive feedback from others out there, so maybe you're interested in pulling these into your official repo.

Best,
Philipp
